### PR TITLE
Add {{markdown-render}} helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ markdownit().render('# A Top Level Header');
 // => "<h1>A Top Level Header</h1>"
 ```
 
+### In your templates
+
+A helper is provided for easily rendering Markdown as HTML in your templates:
+
+```handlebars
+{{markdown-render someMarkdown}}
+```
+
+> Note: This returns an `Ember.Handlebars.SafeString`. We are relying on
+> [markdown-it][markdown-it] for sanitization. For more info, checkout the
+> [markdown-it Security docs][markdown-it-security].
+
 Refer to the [markdown-it documentation][markdown-it] for more information.
 
 [markdown-it]: https://github.com/markdown-it/markdown-it
+[markdown-it-security]: https://github.com/markdown-it/markdown-it/blob/master/docs/security.md

--- a/addon/helpers/markdown-render.js
+++ b/addon/helpers/markdown-render.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import markdownit from 'markdown-it';
+
+const {
+  String: EmString,
+  isEmpty
+} = Ember;
+
+const { htmlSafe } = EmString;
+
+export function markdownRender(params) {
+  if (isEmpty(params)) {
+    return;
+  }
+
+  let [markdown] = params;
+  let html = markdownit().render(markdown);
+
+  return htmlSafe(html);
+}
+
+export default Ember.Helper.helper(markdownRender);

--- a/app/helpers/markdown-render.js
+++ b/app/helpers/markdown-render.js
@@ -1,0 +1,1 @@
+export { default, markdownRender } from 'ember-markdown-it/helpers/markdown-render';

--- a/tests/unit/helpers/markdown-render-test.js
+++ b/tests/unit/helpers/markdown-render-test.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+import { markdownRender } from 'dummy/helpers/markdown-render';
+import { module, test } from 'qunit';
+
+const { Handlebars } = Ember;
+const { SafeString } = Handlebars;
+
+module('Unit | Helper | markdown render');
+
+test('it returns given markdown rendered as HTML within a SafeString', function(assert) {
+  let markdown = `# I am a header`;
+  let expected = new SafeString(`<h1>I am a header</h1>\n`);
+
+  let result = markdownRender([markdown]);
+
+  assert.deepEqual(result, expected,
+    'returns a SafeString markdown rendered as HTML');
+});
+
+test('it gracefully handles null values', function(assert) {
+  markdownRender(null);
+
+  assert.ok(true, 'We made it this far without errors');
+});
+
+test('it gracefully handles undefined values', function(assert) {
+  markdownRender(undefined);
+
+  assert.ok(true, 'We made it this far without errors');
+});


### PR DESCRIPTION
Closes https://github.com/greenfieldhq/ember-markdown-it/issues/1
### Usage:

``` handlebars
{{markdown-render someMarkdown}}
```
### Deets

This helper can be used in templates in order to render markdown as
HTML. It returns an `Ember.Handlebars.SafeString`, which may not always
be what you want to allow, but we're relying on markdown-it to provide
sanitization of the string for us.

In the future, I'd like to make this configurable.
