### PR TITLE
Prevent missing entity name error on install

### DIFF
--- a/blueprints/ember-markdown-it/index.js
+++ b/blueprints/ember-markdown-it/index.js
@@ -1,5 +1,9 @@
 /*jshint node:true*/
 module.exports = {
+  normalizeEntityName: function() {
+    // no-op since we're just adding dependencies
+  },
+
   afterInstall: function() {
     return this.addBowerPackageToProject('markdown-it');
   }


### PR DESCRIPTION
Prevents the following error on install:

```
$ ember install ember-markdown-it
version: 2.4.2
Installed packages for tooling via npm.
installing ember-markdown-it
The `ember generate <entity-name>` command requires an entity name to be specified. For more details, use `ember help`.
```
